### PR TITLE
Don't crash on failed GPU freq; find GPU1; add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Makefile for cpumon project
+
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c99
+LDFLAGS = -lncurses -lm
+
+SRC_DIR = ./src
+OBJ_DIR = ./obj
+
+SOURCES = cpumon.c $(wildcard $(SRC_DIR)/*.c)
+OBJECTS = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SOURCES))
+
+TARGET = cpumon
+INSTALL_PATH = /usr/bin
+
+.PHONY: all clean install
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(OBJECTS) -o $(TARGET) $(LDFLAGS)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
+install: $(TARGET)
+	cp $(TARGET) $(INSTALL_PATH)
+
+clean:
+	rm -f $(OBJ_DIR)/*.o $(TARGET)
+	rmdir $(OBJ_DIR) || true

--- a/src/cpumonlib.c
+++ b/src/cpumonlib.c
@@ -513,21 +513,38 @@ double * power_units(void){
 }
 
 
+FILE* get_gpu_card(void){
+    static char* gpu_0_file = "/sys/class/drm/card0/gt_cur_freq_mhz";
+    static char* gpu_1_file = "/sys/class/drm/card1/gt_cur_freq_mhz";
+    FILE *fp = NULL;
+
+    if (access(gpu_0_file, F_OK) == 0)
+    {
+        fp = fopen(gpu_0_file, "r");
+    }
+    printf("Couldn't read GPU frequency from: %s", gpu_0_file);
+    if (access(gpu_1_file, F_OK) == 0)
+    {
+        fp = fopen(gpu_1_file, "r");
+    }
+    printf("Couldn't read GPU frequency from: %s", gpu_1_file);
+    return fp;
+}
+
 int gpu(void){
     
     char file_buf[BUFSIZE];
-    static int freq_mhz;
+    static int freq_mhz = -1;
 
-    FILE *fp = fopen("/sys/class/drm/card0/gt_cur_freq_mhz", "r");
-    if (fp == NULL){
-        perror("Error reading GPU frequency from /sys/class/drm/card0/gt_cur_freq_mhz\n");
-    }
-    if (fgets(file_buf, BUFSIZE, fp) == NULL)
+    FILE *fp = get_gpu_card();
+
+    if (fp != NULL && fgets(file_buf, BUFSIZE, fp) != NULL)
     {
-        printf("Couldnt read GPU frequency from \"/sys/class/drm/card0/gt_cur_freq_mhz\"\n");
+        sscanf(file_buf, "%d", &freq_mhz);
+        fclose(fp);
     }
-    sscanf(file_buf, "%d", &freq_mhz);
-    fclose(fp);
+
+ 
 
     return freq_mhz;
 


### PR DESCRIPTION
Hi!

On Fedora 39, I've found that my 1135G7 Framework doesn't have a card0 and instead a card1.

I'm super not a C programmer. You can probably tell.

Anyway, I've 
- added a makefile (GPT helped; took some effort to figure out how to build this :P)
- added the possibility of card1 existing and put that into its own function
- made GPU clock default to -1 to prevent crashing if it can't be established.

Please do with these suggested changes as you wish.

Thanks,
Ted